### PR TITLE
Fix bug in tar.js caused by missing `this` on a variable.

### DIFF
--- a/lib/tar.js
+++ b/lib/tar.js
@@ -82,7 +82,7 @@
 
 		// this makes sense if the input is greater than 512 bytes
 		if (headerArr.length + input.length > this.out.length) {
-			this.out = utils.extend(out, headerArr.length, input.length, blockSize);
+			this.out = utils.extend(this.out, headerArr.length, input.length, blockSize);
 		}
 
 		this.out.set(input, this.written);


### PR DESCRIPTION
Yup. Tested and it works.
