### PR TITLE
Fix bugs with this identifier and out array expansion

### DIFF
--- a/lib/tar.js
+++ b/lib/tar.js
@@ -80,9 +80,10 @@
 
 		this.written += headerArr.length;
 
-		// this makes sense if the input is greater than 512 bytes
-		if (headerArr.length + input.length > this.out.length) {
-			this.out = utils.extend(this.out, headerArr.length, input.length, blockSize);
+		// If there is not enough space in this.out, we need to expand it to
+		// fit the new input.
+		if (this.written + input.length > this.out.length) {
+			this.out = utils.extend(this.out, this.written, input.length, blockSize);
 		}
 
 		this.out.set(input, this.written);
@@ -92,7 +93,7 @@
 
 		// make sure there's at least 2 empty records worth of extra space
 		if (this.out.length - this.written < recordSize * 2) {
-			this.out = utils.extend(out, this.written, recordSize * 2, blockSize);
+			this.out = utils.extend(this.out, this.written, recordSize * 2, blockSize);
 		}
 
 		if (typeof callback === 'function') {


### PR DESCRIPTION
Missing another `this` on `out`, and the bounds checking was totally borked.

Bounds checking bug was preventing the size of the out array from being expanded more than once.
